### PR TITLE
Collateral Imbalance test

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ cache
 coverage
 node_modules
 out
+lib/forge-std
 
 # files
 *.env

--- a/src/HypLSP7.sol
+++ b/src/HypLSP7.sol
@@ -19,6 +19,8 @@ contract HypLSP7 is LSP7DigitalAssetInitAbstract, TokenRouter {
     // solhint-disable-next-line immutable-vars-naming
     uint8 private immutable _decimals;
 
+    error InvalidRecipientError();
+
     constructor(uint8 __decimals, address _mailbox) TokenRouter(_mailbox) {
         _decimals = __decimals;
     }
@@ -112,5 +114,43 @@ contract HypLSP7 is LSP7DigitalAssetInitAbstract, TokenRouter {
         override
     {
         LSP7DigitalAssetInitAbstract._mint(_recipient, _amount, true, "");
+    }
+
+    /**
+     * @inheritdoc TokenRouter
+     * @dev Ensures that the recipient of the token transfer is not the collateral contract
+     */
+    function transferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amountOrId
+    )
+        external
+        payable
+        override
+        returns (bytes32 messageId)
+    {
+        if (_recipient == routers(_destination)) revert InvalidRecipientError();
+        return _transferRemote(_destination, _recipient, _amountOrId, msg.value);
+    }
+
+    /**
+     * @inheritdoc TokenRouter
+     * @dev Ensures that the recipient of the token transfer is not the collateral contract
+     */
+    function transferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amountOrId,
+        bytes calldata _hookMetadata,
+        address _hook
+    )
+        external
+        payable
+        override
+        returns (bytes32 messageId)
+    {
+        if (_recipient == routers(_destination)) revert InvalidRecipientError();
+        return _transferRemote(_destination, _recipient, _amountOrId, msg.value, _hookMetadata, _hook);
     }
 }

--- a/src/HypLSP8.sol
+++ b/src/HypLSP8.sol
@@ -18,6 +18,8 @@ import { _LSP8_TOKENID_FORMAT_NUMBER } from "@lukso/lsp8-contracts/contracts/LSP
  * - LSP8 standard: https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-8-IdentifiableDigitalAsset.md
  */
 contract HypLSP8 is LSP8IdentifiableDigitalAssetInitAbstract, TokenRouter {
+    error InvalidRecipientError();
+
     constructor(address _mailbox) TokenRouter(_mailbox) { }
 
     /**
@@ -108,5 +110,43 @@ contract HypLSP8 is LSP8IdentifiableDigitalAssetInitAbstract, TokenRouter {
         override
     {
         _mint(_recipient, bytes32(_tokenId), true, "");
+    }
+
+    /**
+     * @inheritdoc TokenRouter
+     * @dev Ensures that the recipient of the token transfer is not the collateral contract
+     */
+    function transferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amountOrId
+    )
+        external
+        payable
+        override
+        returns (bytes32 messageId)
+    {
+        if (_recipient == routers(_destination)) revert InvalidRecipientError();
+        return _transferRemote(_destination, _recipient, _amountOrId, msg.value);
+    }
+
+    /**
+     * @inheritdoc TokenRouter
+     * @dev Ensures that the recipient of the token transfer is not the collateral contract
+     */
+    function transferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amountOrId,
+        bytes calldata _hookMetadata,
+        address _hook
+    )
+        external
+        payable
+        override
+        returns (bytes32 messageId)
+    {
+        if (_recipient == routers(_destination)) revert InvalidRecipientError();
+        return _transferRemote(_destination, _recipient, _amountOrId, msg.value, _hookMetadata, _hook);
     }
 }

--- a/test/audit/CollateralImbalance.t.sol
+++ b/test/audit/CollateralImbalance.t.sol
@@ -1,0 +1,255 @@
+pragma solidity ^0.8.13;
+
+// test utilities
+import { Test } from "forge-std/src/Test.sol";
+import { Vm } from "forge-std/src/Vm.sol";
+import { console } from "forge-std/src/console.sol";
+
+/// Hyperlane testing environnement
+/// @dev See https://docs.hyperlane.xyz/docs/guides/developer-tips/unit-testing
+import { TypeCasts } from "@hyperlane-xyz/core/contracts/libs/TypeCasts.sol";
+import { TestMailbox } from "@hyperlane-xyz/core/contracts/test/TestMailbox.sol";
+import { TestPostDispatchHook } from "@hyperlane-xyz/core/contracts/test/TestPostDispatchHook.sol";
+import { TestInterchainGasPaymaster } from "@hyperlane-xyz/core/contracts/test/TestInterchainGasPaymaster.sol";
+
+import { GasRouter } from "@hyperlane-xyz/core/contracts/client/GasRouter.sol";
+import { HypNative } from "@hyperlane-xyz/core/contracts/token/HypNative.sol";
+
+// libraries
+import { TokenRouter } from "@hyperlane-xyz/core/contracts/token/libs/TokenRouter.sol";
+import { TokenMessage } from "@hyperlane-xyz/core/contracts/token/libs/TokenMessage.sol";
+
+// Mocks + contracts to test
+import { LSP7Mock } from "../Mocks/LSP7Mock.sol";
+import { HypLSP7 } from "../../src/HypLSP7.sol";
+import { HypLSP7Collateral } from "../../src/HypLSP7Collateral.sol";
+
+contract CollateralImbalance is Test {
+using TypeCasts for address;
+    using TokenMessage for bytes;
+
+    address internal ATTACKER = makeAddr("attacker");
+    address internal OWNER = makeAddr("owner");
+
+    LSP7Mock internal lsp7;
+    HypLSP7Collateral internal collateralToken;
+    // TokenRouter internal localToken;
+    HypLSP7 internal syntheticToken;
+    TestMailbox internal localMailbox;
+    TestMailbox internal remoteMailbox;
+    TestPostDispatchHook internal noopHook;
+    TestInterchainGasPaymaster internal igp;
+
+    uint32 internal constant ORIGIN = 11;
+    uint32 internal constant DESTINATION = 12;
+    uint8 internal constant DECIMALS = 18;
+    uint256 internal constant TOTAL_SUPPLY = 1_000_000e18;
+    uint256 internal constant GAS_LIMIT = 10_000;
+    uint256 internal constant TRANSFER_AMOUNT = 100e18;
+    string internal constant NAME = "HyperlaneInu";
+    string internal constant SYMBOL = "HYP";
+
+    uint256 internal amount = 10 * 10 ** 18;
+    
+    function setUp() public {
+
+        localMailbox = new TestMailbox(ORIGIN);
+        remoteMailbox = new TestMailbox(DESTINATION);
+
+        lsp7 = new LSP7Mock(NAME, SYMBOL, address(this), TOTAL_SUPPLY);
+        collateralToken = new HypLSP7Collateral(address(lsp7), address(localMailbox));
+        collateralToken.initialize(address(noopHook), address(0), OWNER);
+
+        noopHook = new TestPostDispatchHook();
+        localMailbox.setDefaultHook(address(noopHook));
+        localMailbox.setRequiredHook(address(noopHook));
+
+        remoteMailbox.setDefaultHook(address(noopHook));
+        remoteMailbox.setRequiredHook(address(noopHook));
+
+        syntheticToken = new HypLSP7(DECIMALS, address(remoteMailbox));
+
+        syntheticToken.initialize(0, NAME, SYMBOL, address(noopHook), address(0), OWNER, "");
+
+        vm.startPrank(OWNER);
+        syntheticToken.enrollRemoteRouter(ORIGIN, address(collateralToken).addressToBytes32());
+        collateralToken.enrollRemoteRouter(DESTINATION, address(syntheticToken).addressToBytes32());
+        vm.stopPrank();
+    }
+
+    function bridgeToSynthetic() public {
+        // Emulate Transfer of `amount` to HypLSP7Collateral
+        lsp7.mintTo(address(collateralToken), amount);
+
+        // Bridge (ie Mint) the amount stored in collateral 
+        bytes memory _body = TokenMessage.format(
+            ATTACKER.addressToBytes32(), 
+            amount,
+            "");
+        remoteMailbox.testHandle(
+            ORIGIN, 
+            address(collateralToken).addressToBytes32(), 
+            address(syntheticToken).addressToBytes32(), 
+            _body);
+    }
+
+    function bridgeToAddress(bytes32 recipient, TokenRouter sender, TokenRouter receiver, uint32 _fromDomain, uint32 _toDomain, TestMailbox _destMailbox) internal {
+        // bridge `amount` to `recipient`
+        vm.prank(ATTACKER);
+        sender.transferRemote(
+            _toDomain,
+            recipient,
+            amount
+        );
+
+        // recreate the token message sending to `recipient`
+        bytes memory _body = TokenMessage.format(
+            recipient,
+            amount,
+            ""
+        );
+        _destMailbox.testHandle(
+            _fromDomain,
+            address(sender).addressToBytes32(),
+            address(receiver).addressToBytes32(),
+            _body
+        );
+    }
+
+    function bridgeToken(bytes32 recipient, TokenRouter sender, TokenRouter receiver, uint32 _fromDomain, uint32 _toDomain, TestMailbox _destMailbox) internal {
+        // Check the balanceOf Collateral Token with totalSupply of Synthetic
+        uint256 collateralBalance1 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        // console.log("ColBal1 ", collateralBalance1);
+        vm.assertEq(collateralBalance1, totalSupply1);
+
+        bridgeToAddress(recipient, sender, receiver, _fromDomain, _toDomain, _destMailbox);
+    }
+
+    function test_bridgeToCollateralUnknownAddress_NoAccountingError() public {
+        bridgeToSynthetic();
+
+        uint256 collateralBalance0 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+
+        address NOONE = makeAddr("noop");
+        bridgeToken(
+            NOONE.addressToBytes32(), 
+            syntheticToken, 
+            collateralToken,
+            DESTINATION,
+            ORIGIN,
+            localMailbox
+        );
+
+        uint256 collateralBalance1 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        
+        console.log("Previous Balance");
+        console.log("balanceOf(collateral)", collateralBalance0);
+        console.log("totalSupply()", totalSupply0);
+        console.log("Post Balance");
+        console.log("balanceOf(collateral)", collateralBalance1);
+        console.log("totalSupply()", totalSupply1);
+
+        // When bridging to collateral to an uncontrolled address,
+        // the collateral router's balance will reflect the total supply
+        vm.assertEq(collateralBalance1, totalSupply1);
+        vm.assertEq(totalSupply1, 0);
+    }
+
+    function test_bridgeToCollateralRouter_CausesAccountingError() public {
+        bridgeToSynthetic();
+        uint256 collateralBalance0 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+        
+        bridgeToken(
+            address(collateralToken).addressToBytes32(), 
+            syntheticToken, 
+            collateralToken,
+            DESTINATION,
+            ORIGIN,
+            localMailbox
+        );
+
+        uint256 collateralBalance1 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        
+        console.log("Previous Balance");
+        console.log("balanceOf(collateral)", collateralBalance0);
+        console.log("totalSupply()", totalSupply0);
+        console.log("Post Balance");
+        console.log("balanceOf(collateral)", collateralBalance1);
+        console.log("totalSupply()", totalSupply1);
+
+        // when bridging to the collateral token router itself,
+        // balance gets trapped in the collateral token router
+        vm.assertEq(collateralBalance1, totalSupply1);
+        vm.assertEq(totalSupply1, 0);
+    }
+
+    function test_bridgeToSynthetic_UnknownAddress() public {
+        uint256 collateralBalance0 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+        
+        lsp7.mintTo(ATTACKER, amount);
+        vm.prank(ATTACKER);
+        lsp7.authorizeOperator(address(collateralToken), amount, "");
+
+        address NOONE = makeAddr("noop");
+        bridgeToken(
+            NOONE.addressToBytes32(), 
+            collateralToken,
+            syntheticToken,
+            ORIGIN,
+            DESTINATION,
+            remoteMailbox
+        );
+        
+        uint256 collateralBalance1 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        console.log("Previous Balance");
+        console.log("balanceOf(collateral)", collateralBalance0);
+        console.log("totalSupply()", totalSupply0);
+        console.log("Post Balance");
+        console.log("balanceOf(collateral)", collateralBalance1);
+        console.log("totalSupply()", totalSupply1);
+        // when bridging from collateral to synthetic the collateral balance
+        // should equal the synthetic totalSupply regardless of who the 
+        // synthetic tokens are minted to
+        vm.assertEq(collateralBalance1, totalSupply1);
+        vm.assertEq(totalSupply1, amount);
+    }
+
+    function test_bridgeToSynthetic_SyntheticTokenAddress() public {
+        uint256 collateralBalance0 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+        
+        lsp7.mintTo(ATTACKER, amount);
+        vm.prank(ATTACKER);
+        lsp7.authorizeOperator(address(collateralToken), amount, "");
+
+        bridgeToken(
+            address(syntheticToken).addressToBytes32(), 
+            collateralToken,
+            syntheticToken,
+            ORIGIN,
+            DESTINATION,
+            remoteMailbox
+        );
+
+        uint256 collateralBalance1 = lsp7.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        console.log("Previous Balance");
+        console.log("balanceOf(collateral)", collateralBalance0);
+        console.log("totalSupply()", totalSupply0);
+        console.log("Post Balance");
+        console.log("balanceOf(collateral)", collateralBalance1);
+        console.log("totalSupply()", totalSupply1);
+        // when bridging from collateral to synthetic the collateral balance
+        // should equal the synthetic totalSupply regardless of who the 
+        // synthetic tokens are minted to
+        vm.assertEq(collateralBalance1, totalSupply1);
+        vm.assertEq(totalSupply1, amount);
+    }
+}

--- a/test/audit/CollateralImbalanceLSP7.t.sol
+++ b/test/audit/CollateralImbalanceLSP7.t.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.8.13;
 
 // test utilities
 import { Test } from "forge-std/src/Test.sol";
-// import { Vm } from "forge-std/src/Vm.sol";
 import { console } from "forge-std/src/console.sol";
 
 /// Hyperlane testing environnement
@@ -41,7 +40,6 @@ contract CollateralImbalanceLSP7 is Test {
     uint32 internal constant DESTINATION = 12;
     uint8 internal constant DECIMALS = 18;
     uint256 internal constant TOTAL_SUPPLY = 1_000_000e18;
-    uint256 internal constant GAS_LIMIT = 10_000;
     uint256 internal constant TRANSFER_AMOUNT = 100e18;
     string internal constant NAME = "HyperlaneInu";
     string internal constant SYMBOL = "HYP";
@@ -155,6 +153,18 @@ contract CollateralImbalanceLSP7 is Test {
         vm.expectRevert(InvalidRecipientError.selector);
         vm.prank(ATTACKER);
         syntheticToken.transferRemote(ORIGIN, address(collateralToken).addressToBytes32(), amount);
+    }
+
+    function test_bridgeToCollateralRouterWithHook_CausesAccountingError() public {
+        bridgeToSynthetic();
+
+        bytes memory hookMetadata = "";
+
+        vm.expectRevert(InvalidRecipientError.selector);
+        vm.prank(ATTACKER);
+        syntheticToken.transferRemote(
+            ORIGIN, address(collateralToken).addressToBytes32(), amount, hookMetadata, address(noopHook)
+        );
     }
 
     function test_bridgeToSynthetic_UnknownAddress() public {

--- a/test/audit/CollateralImbalanceLSP8.t.sol
+++ b/test/audit/CollateralImbalanceLSP8.t.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.8.13;
 
 // test utilities
 import { Test } from "forge-std/src/Test.sol";
-// import { Vm } from "forge-std/src/Vm.sol";
 import { console } from "forge-std/src/console.sol";
 
 /// Hyperlane testing environnement
@@ -155,12 +154,22 @@ contract CollateralImbalanceLSP8 is Test {
         tokenId += 1;
         bridgeToSynthetic(tokenId);
 
-        uint256 collateralBalance0 = lsp8.balanceOf(address(collateralToken));
-        uint256 totalSupply0 = syntheticToken.totalSupply();
-
         vm.expectRevert(InvalidRecipientError.selector);
         vm.prank(ATTACKER);
         syntheticToken.transferRemote(ORIGIN, address(collateralToken).addressToBytes32(), tokenId);
+    }
+
+    function test_bridgeToCollateralRouterWithHook_CausesAccountingError() public {
+        tokenId += 1;
+        bridgeToSynthetic(tokenId);
+
+        bytes memory hookMetadata = "";
+
+        vm.expectRevert(InvalidRecipientError.selector);
+        vm.prank(ATTACKER);
+        syntheticToken.transferRemote(
+            ORIGIN, address(collateralToken).addressToBytes32(), tokenId, hookMetadata, address(noopHook)
+        );
     }
 
     function test_bridgeToSynthetic_UnknownAddress() public {

--- a/test/audit/CollateralImbalanceLSP8.t.sol
+++ b/test/audit/CollateralImbalanceLSP8.t.sol
@@ -1,0 +1,228 @@
+pragma solidity ^0.8.13;
+
+// test utilities
+import { Test } from "forge-std/src/Test.sol";
+// import { Vm } from "forge-std/src/Vm.sol";
+import { console } from "forge-std/src/console.sol";
+
+/// Hyperlane testing environnement
+/// @dev See https://docs.hyperlane.xyz/docs/guides/developer-tips/unit-testing
+import { TypeCasts } from "@hyperlane-xyz/core/contracts/libs/TypeCasts.sol";
+import { TestMailbox } from "@hyperlane-xyz/core/contracts/test/TestMailbox.sol";
+import { TestPostDispatchHook } from "@hyperlane-xyz/core/contracts/test/TestPostDispatchHook.sol";
+
+// libraries
+import { TokenRouter } from "@hyperlane-xyz/core/contracts/token/libs/TokenRouter.sol";
+import { TokenMessage } from "@hyperlane-xyz/core/contracts/token/libs/TokenMessage.sol";
+
+// Mocks + contracts to test
+import { LSP8Mock } from "../Mocks/LSP8Mock.sol";
+import { HypLSP8 } from "../../src/HypLSP8.sol";
+import { HypLSP8Collateral } from "../../src/HypLSP8Collateral.sol";
+
+contract CollateralImbalanceLSP8 is Test {
+    using TypeCasts for address;
+    using TokenMessage for bytes;
+
+    error InvalidRecipientError();
+
+    address internal ATTACKER = makeAddr("attacker");
+    address internal OWNER = makeAddr("owner");
+
+    LSP8Mock internal lsp8;
+    HypLSP8Collateral internal collateralToken;
+    HypLSP8 internal syntheticToken;
+
+    TestMailbox internal localMailbox;
+    TestMailbox internal remoteMailbox;
+    TestPostDispatchHook internal noopHook;
+
+    uint32 internal constant ORIGIN = 11;
+    uint32 internal constant DESTINATION = 12;
+
+    string internal constant NAME = "HyperlaneInu";
+    string internal constant SYMBOL = "HYP";
+
+    uint256 internal tokenId = 0; // always increments before minting so first minted tokenId will be 1
+
+    function setUp() public {
+        localMailbox = new TestMailbox(ORIGIN);
+        remoteMailbox = new TestMailbox(DESTINATION);
+
+        lsp8 = new LSP8Mock(NAME, SYMBOL, address(this));
+        collateralToken = new HypLSP8Collateral(address(lsp8), address(localMailbox));
+        collateralToken.initialize(address(noopHook), address(0), OWNER);
+
+        noopHook = new TestPostDispatchHook();
+        localMailbox.setDefaultHook(address(noopHook));
+        localMailbox.setRequiredHook(address(noopHook));
+
+        remoteMailbox.setDefaultHook(address(noopHook));
+        remoteMailbox.setRequiredHook(address(noopHook));
+
+        syntheticToken = new HypLSP8(address(remoteMailbox));
+
+        syntheticToken.initialize(0, NAME, SYMBOL, address(noopHook), address(0), OWNER, "");
+
+        vm.startPrank(OWNER);
+        syntheticToken.enrollRemoteRouter(ORIGIN, address(collateralToken).addressToBytes32());
+        collateralToken.enrollRemoteRouter(DESTINATION, address(syntheticToken).addressToBytes32());
+        vm.stopPrank();
+    }
+
+    function bridgeToSynthetic(uint256 _tokenId) public {
+        // Emulate Transfer of `tokenId` to HypLSP7Collateral
+        lsp8.mint(address(collateralToken), bytes32(_tokenId), true, "");
+
+        // Bridge (ie Mint) the tokenId stored in collateral
+        bytes memory _body = TokenMessage.format(ATTACKER.addressToBytes32(), _tokenId, "");
+        remoteMailbox.testHandle(
+            ORIGIN, address(collateralToken).addressToBytes32(), address(syntheticToken).addressToBytes32(), _body
+        );
+    }
+
+    function bridgeToAddress(
+        bytes32 recipient,
+        TokenRouter sender,
+        TokenRouter receiver,
+        uint32 _fromDomain,
+        uint32 _toDomain,
+        TestMailbox _destMailbox,
+        uint256 _tokenId
+    )
+        internal
+    {
+        // bridge `tokenId` to `recipient`
+        vm.prank(ATTACKER);
+        sender.transferRemote(_toDomain, recipient, _tokenId);
+
+        // recreate the token message sending to `recipient`
+        bytes memory _body = TokenMessage.format(recipient, _tokenId, "");
+
+        _destMailbox.testHandle(
+            _fromDomain, address(sender).addressToBytes32(), address(receiver).addressToBytes32(), _body
+        );
+    }
+
+    function bridgeToken(
+        bytes32 recipient,
+        TokenRouter sender,
+        TokenRouter receiver,
+        uint32 _fromDomain,
+        uint32 _toDomain,
+        TestMailbox _destMailbox,
+        uint256 _tokenId
+    )
+        internal
+    {
+        // Check the balanceOf Collateral Token with totalSupply of Synthetic
+        uint256 collateralBalance1 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        vm.assertEq(collateralBalance1, totalSupply1);
+
+        bridgeToAddress(recipient, sender, receiver, _fromDomain, _toDomain, _destMailbox, _tokenId);
+    }
+
+    function test_bridgeToCollateralUnknownAddress_NoAccountingError() public {
+        tokenId += 1;
+        bridgeToSynthetic(tokenId);
+
+        uint256 collateralBalance0 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+
+        address NOONE = makeAddr("noop");
+        bridgeToken(
+            NOONE.addressToBytes32(), syntheticToken, collateralToken, DESTINATION, ORIGIN, localMailbox, tokenId
+        );
+
+        uint256 collateralBalance1 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+
+        console.log("Previous Balance");
+        console.log("balanceOf(collateral)", collateralBalance0);
+        console.log("totalSupply()", totalSupply0);
+        console.log("Post Balance");
+        console.log("balanceOf(collateral)", collateralBalance1);
+        console.log("totalSupply()", totalSupply1);
+
+        // When bridging to collateral to an uncontrolled address,
+        // the collateral router's balance will reflect the total supply
+        vm.assertEq(collateralBalance1, totalSupply1);
+        vm.assertEq(totalSupply1, 0);
+    }
+
+    function test_bridgeToCollateralRouter_CausesAccountingError() public {
+        tokenId += 1;
+        bridgeToSynthetic(tokenId);
+
+        uint256 collateralBalance0 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+
+        vm.expectRevert(InvalidRecipientError.selector);
+        vm.prank(ATTACKER);
+        syntheticToken.transferRemote(ORIGIN, address(collateralToken).addressToBytes32(), tokenId);
+    }
+
+    function test_bridgeToSynthetic_UnknownAddress() public {
+        uint256 collateralBalance0 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+
+        tokenId += 1;
+        lsp8.mint(ATTACKER, bytes32(tokenId), true, "");
+        vm.prank(ATTACKER);
+        lsp8.authorizeOperator(address(collateralToken), bytes32(tokenId), "");
+
+        address NOONE = makeAddr("noop");
+        bridgeToken(
+            NOONE.addressToBytes32(), collateralToken, syntheticToken, ORIGIN, DESTINATION, remoteMailbox, tokenId
+        );
+
+        uint256 collateralBalance1 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        console.log("Previous Balance");
+        console.log("balanceOf(collateral)", collateralBalance0);
+        console.log("totalSupply()", totalSupply0);
+        console.log("Post Balance");
+        console.log("balanceOf(collateral)", collateralBalance1);
+        console.log("totalSupply()", totalSupply1);
+        // when bridging from collateral to synthetic the collateral balance
+        // should equal the synthetic totalSupply regardless of who the
+        // synthetic tokens are minted to
+        vm.assertEq(collateralBalance1, totalSupply1);
+        vm.assertEq(totalSupply1, tokenId);
+    }
+
+    function test_bridgeToSynthetic_SyntheticTokenAddress() public {
+        uint256 collateralBalance0 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply0 = syntheticToken.totalSupply();
+
+        tokenId += 1;
+        lsp8.mint(ATTACKER, bytes32(tokenId), true, "");
+        vm.prank(ATTACKER);
+        lsp8.authorizeOperator(address(collateralToken), bytes32(tokenId), "");
+
+        bridgeToken(
+            address(syntheticToken).addressToBytes32(),
+            collateralToken,
+            syntheticToken,
+            ORIGIN,
+            DESTINATION,
+            remoteMailbox,
+            tokenId
+        );
+
+        uint256 collateralBalance1 = lsp8.balanceOf(address(collateralToken));
+        uint256 totalSupply1 = syntheticToken.totalSupply();
+        console.log("Previous Balance");
+        console.log("balanceOf(collateral)", collateralBalance0);
+        console.log("totalSupply()", totalSupply0);
+        console.log("Post Balance");
+        console.log("balanceOf(collateral)", collateralBalance1);
+        console.log("totalSupply()", totalSupply1);
+        // when bridging from collateral to synthetic the collateral balance
+        // should equal the synthetic totalSupply regardless of who the
+        // synthetic tokens are minted to
+        vm.assertEq(collateralBalance1, totalSupply1);
+        vm.assertEq(totalSupply1, tokenId);
+    }
+}


### PR DESCRIPTION
CollateralImbalance.t.sol provides 4 tests to demonstrate the following scenarios where a user mistakenly bridges to an address they do not control.

1. Bridging collateral => synthetic where the token recipient on the destination chain is an arbitrary address
2. Bridging collateral => synthetic where the token recipient on the destination chain is the synthetic token router
3. Bridging synthetic => collateral where the token recipient is an arbitrary address
4. Bridging synthetic => collateral where the token recipient is the collateral token router

Scenarios 2 and 4 share the same edge case where the recipient of the token is a token router. However, the accounting balances for scenarios 1 and 2 are the same. This is because for a synthetic token such as HypLSP7, the Total Supply is representative of what is stored in the Collateral Token Router's balance of the wrapped token. 

Accounting balance in an ideal situation absent of user error should be:
`lsp7.balanceOf(collateralToken) == synthetic.totalSupply()`

In all 4 scenarios, due to user error, this equation will be violated. In scenarios 1 and 2, bridging tokens to uncontrolled addresses with balances will permanently increase the Total Supply of the synthetic token. It does not matter what address owns the tokens. We are do not make accounting calculations on whether the Synthetic Token contract owns some of its own tokens.

Scenarios 3 and 4 are different because on the Collateral side of the warp route, there are two separate contracts. LSP7 is the token contract. This contract maintains balances of token holders. The Collateral Token Router holds tokens (in collateral) before bridging. Here the distinction is import.

In scenario 3, the recipient address is an arbitrary, uncontrolled address. The Collateral Contract will transfer the bridged amount to this arbitrary address. The balances are updated in the LSP7 contract. The balance of the Collateral Contract in LSP7 will be reduced to match the total supply on the synthetic contract.

In scenario 4, the collateral contract transfers the tokens to itself. The synthetic contract's total supply is reduced through burning, but the Collateral contract's balance of LSP7 tokens remains the same. 

Preventing all types of user error is not feasible. Scenarios 2 and 4 are similar in that they lock up tokens in the token routers. Because the effect of scenario 1 and 2 is ultimately the same, there is no point in adding additional checks. Nothing would be gained. 

Scenario 4 is unique because of the difference with Scenario 3. A check to prevent Scenario 4 would ensure that token loss on the Collateral side of the warp route would not imbalance bridging accounting.