### PR TITLE
fix: add contract existence check in `HypLSP8Collateral`

### DIFF
--- a/src/HypLSP8Collateral.sol
+++ b/src/HypLSP8Collateral.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.19;
 
-import { TokenRouter } from "@hyperlane-xyz/core/contracts/token/libs/TokenRouter.sol";
-
+// Interfaces
 import { ILSP8IdentifiableDigitalAsset as ILSP8 } from
     "@lukso/lsp8-contracts/contracts/ILSP8IdentifiableDigitalAsset.sol";
+
+// Modules
+import { TokenRouter } from "@hyperlane-xyz/core/contracts/token/libs/TokenRouter.sol";
+
+// Libraries
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @title Hyperlane LSP8 Token Collateral that wraps an existing LSP8 with remote transfer functionality.
@@ -19,6 +24,8 @@ contract HypLSP8Collateral is TokenRouter {
      * @param lsp8_ Address of the token to keep as collateral
      */
     constructor(address lsp8_, address mailbox_) TokenRouter(mailbox_) {
+        // solhint-disable-next-line custom-errors
+        require(Address.isContract(lsp8_), "HypLSP8Collateral: invalid token");
         wrappedToken = ILSP8(lsp8_);
     }
 


### PR DESCRIPTION
The `HypLSP8Collateral` contract's `constructor` does not validate that the provided LSP8 token address is a valid contract address. 
This is inconsistent with the `HypLSP7Collateral` contract which properly performs this check. In `HypLSP7Collateral.sol`, the constructor validates the token address.

Without this validation, it's possible to deploy the `HypLSP8Collateral` contract with an invalid or non-existent token address. If the `lsp8_` address is not a contract, all token operations will fail, rendering the collateral
contract unusable and result in the deployment of non-functional collateral contracts.

![image](https://github.com/user-attachments/assets/bd0bf9be-2894-4175-8c43-8cd3d36662a0)

