### PR TITLE
refactor: set `isNonDivisible_` in initialize according to `_decimals` in the implementation

### DIFF
--- a/src/HypLSP7.sol
+++ b/src/HypLSP7.sol
@@ -52,8 +52,11 @@ contract HypLSP7 is LSP7DigitalAssetInitAbstract, FungibleTokenRouter {
             symbol_: tokenSymbol,
             newOwner_: contractOwner,
             lsp4TokenType_: _LSP4_TOKEN_TYPE_TOKEN,
-            isNonDivisible_: false // isNonDivisible set to `false` as not used anyway since decimals() is overriden
-         });
+            // Even if the `_isNonDivisible` state variable is not used because it is overriden by the `decimals()`
+            // function below, ensure its value is set correctly in the proxy contract's storage,
+            // according to the `_decimals` immutable variable derived from the implementation.
+            isNonDivisible_: _decimals == 0
+        });
 
         // Initializes the warp route
         _MailboxClient_initialize(defaultHook, defaultInterchainSecurityModule, contractOwner);

--- a/src/HypLSP7Collateral.sol
+++ b/src/HypLSP7Collateral.sol
@@ -82,7 +82,8 @@ contract HypLSP7Collateral is MovableCollateralRouter {
     /**
      * @dev LSP7 compatible version of the `MovableCollateralRouter.approveTokenForBridge(...)` function.
      *
-     * @dev Note that the `approveTokenForBridge(...)` still exists in the ABI of this contract and can still be called
+     * @custom:warning Note that the `approveTokenForBridge(...)` still exists in the ABI of this contract and can still
+     * be called
      * by the contract owner. Calling `approveTokenForBridge(...)` will attempt to call `approve(address,uint256)`
      * on the `token` contract passed as parameter.
      *


### PR DESCRIPTION
 If the `HypLSP7` contract is linked to an implementation that was deployed with the parameter `decimals_` in the constructor set to 0, the state variable `_isNonDivisible` (derived from `LSP7DigitalAssetInitAbstract` in the proxy storage will still be set to `false` in our current code. 
 
This is not a big issue (as `_isNonDivisible` state variable is not used) but the contract storage would not match the decimals number because in the current logic of `HypLSP7`, when initializing the proxy, `_isNonDivisible` is hardcoded to be set to `false` when `initialize(...)` is called.

This PR refactors the logic to ensure the storage value is rightly set according to the `_decimals` immutable variable set in the implementation and derived from it.